### PR TITLE
Enable Edge TPU export and inference for newer Tensorflow versions

### DIFF
--- a/py_src/yolov4/tf/__init__.py
+++ b/py_src/yolov4/tf/__init__.py
@@ -150,8 +150,8 @@ class YOLOv4(BaseClass):
             converter.experimental_new_converter = False
             converter.representative_dataset = representative_dataset_gen
             _supported_ops += [tf.lite.OpsSet.TFLITE_BUILTINS_INT8]
-            converter.inference_input_type = tf.int8
-            converter.inference_output_type = tf.int8
+            converter.inference_input_type = tf.uint8
+            converter.inference_output_type = tf.uint8
         elif quantization:
             raise ValueError(
                 "YOLOv4: {} is not a valid option".format(quantization)

--- a/py_src/yolov4/tf/__init__.py
+++ b/py_src/yolov4/tf/__init__.py
@@ -147,6 +147,7 @@ class YOLOv4(BaseClass):
         elif quantization == "int":
             converter.representative_dataset = representative_dataset_gen
         elif quantization == "full_int8":
+            converter.experimental_new_converter = False
             converter.representative_dataset = representative_dataset_gen
             _supported_ops += [tf.lite.OpsSet.TFLITE_BUILTINS_INT8]
             converter.inference_input_type = tf.int8

--- a/py_src/yolov4/tflite/__init__.py
+++ b/py_src/yolov4/tflite/__init__.py
@@ -94,11 +94,13 @@ class YOLOv4(BaseClass):
         self.interpreter.invoke()
         if not self.tpu:
             candidates = [
-                self.interpreter.get_tensor(index) for index in self.output_index
+                self.interpreter.get_tensor(index)
+                for index in self.output_index
             ]
         else:
             candidates = [
-                self.interpreter.get_tensor(index).astype(np.float32) / 255.0 for index in self.output_index
+                self.interpreter.get_tensor(index).astype(np.float32) / 255.0
+                for index in self.output_index
             ]
         _candidates = []
         for candidate in candidates:

--- a/test/export.py
+++ b/test/export.py
@@ -1,0 +1,45 @@
+""" 
+export model as keras, onnx and edge tpu model
+
+onnx export requires tensorflow-onnx package
+"""
+
+import tensorflow as tf
+import subprocess
+from yolov4.tf import YOLOv4
+
+MODEL_PATH = "tiny_yolov4_relu/"
+WEIGHT_PATH = "yolov4-tiny-relu.weights"
+DATASET_PATH = "path/to/dataset"
+
+# create model
+yolov4 = YOLOv4(tiny=True, tpu=True)
+yolov4.classes = "dataset/coco.names"
+yolov4.make_model(activation1="relu")
+yolov4.load_weights(WEIGHT_PATH, weights_type="yolo")
+
+# save as keras model
+yolov4.model.save(MODEL_PATH)
+
+# save as onnx model
+try:
+    subprocess.run(["python", "-m", "tf2onnx.convert", "--opset", "12",
+                    "--saved-model", MODEL_PATH, "--output", MODEL_PATH + "model.onnx"],
+                    stdout=subprocess.PIPE, stderr=subprocess.PIPE, check=True)
+except:
+    pass
+
+# callibrate with coco dataset
+dataset = yolov4.load_dataset(
+    dataset_path="dataset/train2017.txt",
+    training=False,
+    image_path_prefix=DATASET_PATH
+)
+
+# save quantization aware model
+yolov4.save_as_tflite(
+    MODEL_PATH + "quant_model.tflite",
+    quantization="full_int8",
+    data_set=dataset,
+    num_calibration_steps=250
+)

--- a/test/export.py
+++ b/test/export.py
@@ -23,9 +23,22 @@ yolov4.model.save(MODEL_PATH)
 
 # save as onnx model
 try:
-    subprocess.run(["python", "-m", "tf2onnx.convert", "--opset", "12",
-                    "--saved-model", MODEL_PATH, "--output", MODEL_PATH + "model.onnx"],
-                    stdout=subprocess.PIPE, stderr=subprocess.PIPE, check=True)
+    subprocess.run(
+        [
+            "python",
+            "-m",
+            "tf2onnx.convert",
+            "--opset",
+            "12",
+            "--saved-model",
+            MODEL_PATH,
+            "--output",
+            MODEL_PATH + "model.onnx",
+        ],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=True,
+    )
 except:
     pass
 
@@ -33,7 +46,7 @@ except:
 dataset = yolov4.load_dataset(
     dataset_path="dataset/train2017.txt",
     training=False,
-    image_path_prefix=DATASET_PATH
+    image_path_prefix=DATASET_PATH,
 )
 
 # save quantization aware model
@@ -41,5 +54,5 @@ yolov4.save_as_tflite(
     MODEL_PATH + "quant_model.tflite",
     quantization="full_int8",
     data_set=dataset,
-    num_calibration_steps=250
+    num_calibration_steps=250,
 )

--- a/test/test_tpu.py
+++ b/test/test_tpu.py
@@ -1,0 +1,17 @@
+"""
+test script for edge tpu model
+"""
+
+from yolov4.tflite import YOLOv4
+import cv2
+
+IMAGE_PATH = "kite.jpg"
+MODEL_PATH = "quant_model_edgetpu.tflite"
+
+yolo = YOLOv4(tiny=True, tpu=True)
+
+yolo.classes = "dataset/coco.names"
+
+yolo.load_tflite(MODEL_PATH)
+
+yolo.inference(IMAGE_PATH) 

--- a/test/test_tpu.py
+++ b/test/test_tpu.py
@@ -14,4 +14,4 @@ yolo.classes = "dataset/coco.names"
 
 yolo.load_tflite(MODEL_PATH)
 
-yolo.inference(IMAGE_PATH) 
+yolo.inference(IMAGE_PATH)


### PR DESCRIPTION
As discussed in issue #20, the new tflite converter does not work together with the yolov4 implementation. To fix this, the new converter was disabled. Additionally, input and output quantization was switched to uint8 in order to avoid unnecessary casting.

The tflite inference module was extended to deal with quantized inputs and outputs. The module now priorises tflite_runtime  before the buildin tensorflow implementation. This should make edge tpu inference easier. 

I added two scripts for model export and inference to evaluate the code.