### PR TITLE
allow media_path to be video stream id

### DIFF
--- a/py_src/yolov4/common/base_class.py
+++ b/py_src/yolov4/common/base_class.py
@@ -238,7 +238,7 @@ class BaseClass:
         iou_threshold: float = 0.3,
         score_threshold: float = 0.25,
     ):
-        if not path.exists(media_path):
+        if isinstance(media_path, str) and not path.exists(media_path):
             raise FileNotFoundError("{} does not exist".format(media_path))
 
         cv2.namedWindow("result", cv2.WINDOW_AUTOSIZE)


### PR DESCRIPTION
If we want to pass a video stream id to inference function, we should
not check the path if is_image is false.