### PR TITLE
Replaced reading of image from open-cv to pyTurboJpeg

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ train*
 venv
 yolov4.egg-info
 *.zip
+.idea/

--- a/py_src/yolov4/common/base_class.py
+++ b/py_src/yolov4/common/base_class.py
@@ -80,7 +80,7 @@ class BaseClass:
         )
 
     def fit_to_original(
-            self, pred_bboxes: np.ndarray, origin_height: int, origin_width: int
+        self, pred_bboxes: np.ndarray, origin_height: int, origin_width: int
     ):
         """
         Warning! change pred_bboxes directly
@@ -136,14 +136,14 @@ class BaseClass:
         return [[0.0, 0.0, 0.0, 0.0, -1]]
 
     def inference(
-            self,
-            media_path,
-            is_image: bool = True,
-            cv_apiPreference=None,
-            cv_frame_size: tuple = None,
-            cv_fourcc: str = None,
-            cv_waitKey_delay: int = 1,
-            prob_thresh: float = 0.25,
+        self,
+        media_path,
+        is_image: bool = True,
+        cv_apiPreference=None,
+        cv_frame_size: tuple = None,
+        cv_fourcc: str = None,
+        cv_waitKey_delay: int = 1,
+        prob_thresh: float = 0.25,
     ):
         if isinstance(media_path, str) and not path.exists(media_path):
             raise FileNotFoundError("{} does not exist".format(media_path))
@@ -154,7 +154,9 @@ class BaseClass:
             with open(media_path, "rb") as f:
                 imageFile = f.read()
                 frame = self.turboJpeg.decode(imageFile)
-                frame_rgb = self.turboJpeg.decode(imageFile, pixel_format=TJPF_RGB)
+                frame_rgb = self.turboJpeg.decode(
+                    imageFile, pixel_format=TJPF_RGB
+                )
 
             start_time = time.time()
             bboxes = self.predict(frame_rgb, prob_thresh=prob_thresh)

--- a/py_src/yolov4/common/base_class.py
+++ b/py_src/yolov4/common/base_class.py
@@ -34,11 +34,13 @@ from ._common import (
     get_yolo_tiny_detections as _get_yolo_tiny_detections,
     fit_to_original as _fit_to_original,
 )
+from turbojpeg import TurboJPEG, TJPF_RGB
 
 
 class BaseClass:
     def __init__(self):
         self.config = YOLOConfig()
+        self.turboJpeg = TurboJPEG()
 
     def get_yolo_detections(self, yolos, prob_thresh: float) -> np.ndarray:
         """
@@ -78,7 +80,7 @@ class BaseClass:
         )
 
     def fit_to_original(
-        self, pred_bboxes: np.ndarray, origin_height: int, origin_width: int
+            self, pred_bboxes: np.ndarray, origin_height: int, origin_width: int
     ):
         """
         Warning! change pred_bboxes directly
@@ -134,14 +136,14 @@ class BaseClass:
         return [[0.0, 0.0, 0.0, 0.0, -1]]
 
     def inference(
-        self,
-        media_path,
-        is_image: bool = True,
-        cv_apiPreference=None,
-        cv_frame_size: tuple = None,
-        cv_fourcc: str = None,
-        cv_waitKey_delay: int = 1,
-        prob_thresh: float = 0.25,
+            self,
+            media_path,
+            is_image: bool = True,
+            cv_apiPreference=None,
+            cv_frame_size: tuple = None,
+            cv_fourcc: str = None,
+            cv_waitKey_delay: int = 1,
+            prob_thresh: float = 0.25,
     ):
         if isinstance(media_path, str) and not path.exists(media_path):
             raise FileNotFoundError("{} does not exist".format(media_path))
@@ -149,8 +151,10 @@ class BaseClass:
         cv2.namedWindow("result", cv2.WINDOW_AUTOSIZE)
 
         if is_image:
-            frame = cv2.imread(media_path)
-            frame_rgb = cv2.cvtColor(frame, cv2.COLOR_BGR2RGB)
+            with open(media_path, "rb") as f:
+                imageFile = f.read()
+                frame = self.turboJpeg.decode(imageFile)
+                frame_rgb = self.turboJpeg.decode(imageFile, pixel_format=TJPF_RGB)
 
             start_time = time.time()
             bboxes = self.predict(frame_rgb, prob_thresh=prob_thresh)

--- a/py_src/yolov4/tf/dataset/keras_sequence.py
+++ b/py_src/yolov4/tf/dataset/keras_sequence.py
@@ -25,7 +25,7 @@ SOFTWARE.
 """
 from typing import List
 
-import cv2
+from turbojpeg import TurboJPEG, TJPF_RGB
 import numpy as np
 from tensorflow.keras.utils import Sequence
 
@@ -65,7 +65,7 @@ class YOLODataset(Sequence):
             raise RuntimeError(
                 "YOLODataset: model does not have a yolo or yolo_tpu layer"
             )
-
+        self.turboJpeg = TurboJPEG()
         self._metanet = config.net
         self._metayolos_np = np.zeros(
             (len(self._metayolos), 7 + len(self._metayolos[-1].mask)),
@@ -127,8 +127,9 @@ class YOLODataset(Sequence):
         """
         # pylint: disable=bare-except
         try:
-            image = cv2.imread(dataset[0])
-            image = cv2.cvtColor(image, cv2.COLOR_BGR2RGB)
+            with open(dataset[0], "rb") as f:
+                image = self.turboJpeg.decode(f.read(), pixel_format=TJPF_RGB)
+
         except:
             return None, None
 

--- a/py_src/yolov4/tf/utils/mAP.py
+++ b/py_src/yolov4/tf/utils/mAP.py
@@ -24,17 +24,17 @@ SOFTWARE.
 from os import makedirs, path
 import shutil
 
-import cv2
+from turbojpeg import TurboJPEG, TJPF_RGB
 import numpy as np
 from tqdm import tqdm
 
 
 def create_mAP_input_files(
-    yolo,
-    dataset,
-    mAP_path: str,
-    images_optional: bool = False,
-    num_sample: int = None,
+        yolo,
+        dataset,
+        mAP_path: str,
+        images_optional: bool = False,
+        num_sample: int = None,
 ):
     """
     Ref: https://github.com/Cartucho/mAP
@@ -81,16 +81,17 @@ def create_mAP_input_files(
             target_path = path.join(img_dir_path, "image_{}.jpg".format(i))
             shutil.copy(image_path, target_path)
 
-        image = cv2.imread(image_path)
-        image = cv2.cvtColor(image, cv2.COLOR_BGR2RGB)
+        with open(image_path, "rb") as f:
+            image = TurboJPEG().decode(f.read(), pixel_format=TJPF_RGB)
+
         height, width, _ = image.shape
 
         gt_bboxes = gt_bboxes * np.array([width, height, width, height, 1])
 
         # ground-truth
         with open(
-            path.join(gt_dir_path, "image_{}.txt".format(i)),
-            "w",
+                path.join(gt_dir_path, "image_{}.txt".format(i)),
+                "w",
         ) as fd:
             for xywhc in gt_bboxes:
                 # name left top right bottom
@@ -114,8 +115,8 @@ def create_mAP_input_files(
 
         # detection-results
         with open(
-            path.join(dr_dir_path, "image_{}.txt".format(i)),
-            "w",
+                path.join(dr_dir_path, "image_{}.txt".format(i)),
+                "w",
         ) as fd:
             for xywhcp in pred_bboxes:
                 # name confidence left top right bottom

--- a/py_src/yolov4/tf/utils/mAP.py
+++ b/py_src/yolov4/tf/utils/mAP.py
@@ -30,11 +30,11 @@ from tqdm import tqdm
 
 
 def create_mAP_input_files(
-        yolo,
-        dataset,
-        mAP_path: str,
-        images_optional: bool = False,
-        num_sample: int = None,
+    yolo,
+    dataset,
+    mAP_path: str,
+    images_optional: bool = False,
+    num_sample: int = None,
 ):
     """
     Ref: https://github.com/Cartucho/mAP
@@ -90,8 +90,8 @@ def create_mAP_input_files(
 
         # ground-truth
         with open(
-                path.join(gt_dir_path, "image_{}.txt".format(i)),
-                "w",
+            path.join(gt_dir_path, "image_{}.txt".format(i)),
+            "w",
         ) as fd:
             for xywhc in gt_bboxes:
                 # name left top right bottom
@@ -115,8 +115,8 @@ def create_mAP_input_files(
 
         # detection-results
         with open(
-                path.join(dr_dir_path, "image_{}.txt".format(i)),
-                "w",
+            path.join(dr_dir_path, "image_{}.txt".format(i)),
+            "w",
         ) as fd:
             for xywhcp in pred_bboxes:
                 # name confidence left top right bottom

--- a/setup.cfg
+++ b/setup.cfg
@@ -32,6 +32,7 @@ zip_safe = False
 install_requires =
     numpy>=1.18.0
     tqdm
+    PyTurboJPEG==1.5.1
 
 [options.packages.find]
 where = py_src


### PR DESCRIPTION
Increased Performance by using PyTurboJPEG for reading images in RGB format.

https://github.com/lilohuang/PyTurboJPEG

Issue Number: #85 
## Benchmark 

### macOS
- macOS Sierra 10.12.6
- Intel(R) Core(TM) i5-3210M CPU @ 2.50GHz
- opencv-python 3.4.0.12 (pre-built)
- turbo-jpeg 1.5.3 (pre-built)

| Function              | Wall-clock time |
| ----------------------|-----------------|
| cv2.imdecode()        |   0.528 sec     |
| TurboJPEG.decode()    |   0.191 sec     |
| cv2.imencode()        |   0.875 sec     |
| TurboJPEG.encode()    |   0.176 sec     |

### Windows 
- Windows 7 Ultimate 64-bit
- Intel(R) Xeon(R) E3-1276 v3 CPU @ 3.60 GHz
- opencv-python 3.4.0.12 (pre-built)
- turbo-jpeg 1.5.3 (pre-built)

| Function              | Wall-clock time |
| ----------------------|-----------------|
| cv2.imdecode()        |   0.358 sec     |
| TurboJPEG.decode()    |   0.135 sec     |
| cv2.imencode()        |   0.581 sec     |
| TurboJPEG.encode()    |   0.140 sec     |